### PR TITLE
fix inconsistent argument, enable swap if needed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,12 +101,12 @@ if [[ -z $BUILD_KERNEL ]] && [[ -z $BUILD_ROOTFS ]]; then
     [[ $selection == *8* ]] && ZRAM_ENABLED='on'
 
 else # at least kernel or rootfs has been selected via command line, check other options and set defaults
-    [[ -z $CLEAN_KERNEL_SRC  ]] && CLEAN_KERNEL_SRC='on'
+    [[ -z $CLEAN_KERNEL_SRC  ]] && CLEAN_KERNEL_SRC='off'
     [[ -z $ALLOW_KERNEL_CONFIG_CHANGES  ]] && ALLOW_KERNEL_CONFIG_CHANGES='off'
 
     [[ -z $ALLOW_ROOTFS_CHANGES  ]] && ALLOW_ROOTFS_CHANGES='off' 
     [[ -z $ASK_EXTRA_PKGS  ]] && ASK_EXTRA_PKGS='off'
-    [[ -z $ZRAM_ENABLED  ]] && ZRAM_ENABLED='on'
+    [[ -z $ZRAM_ENABLED  ]] && ZRAM_ENABLED='off'
 fi
 
 

--- a/tweaks/etc/fstab.hdd
+++ b/tweaks/etc/fstab.hdd
@@ -11,5 +11,5 @@ sysfs           /sys            sysfs   defaults                                
 
 # Add swap and tmpfs only use if not using ZRAM
 #/dev/sda1      swap            swap    defaults                                                        0       0
-#tmpfs          /#t#m#p         tmpfs   mode=1777                                                       0       0
+#tmpfs          /tmp            tmpfs   defaults,noatime,mode=1777,size=25%                             0       0
 

--- a/tweaks/etc/fstab.usb
+++ b/tweaks/etc/fstab.usb
@@ -11,7 +11,7 @@ sysfs           /sys            sysfs   defaults                                
 
 # Add swap and tmpfs only use if not using ZRAM
 #/dev/sdb3      swap            swap    defaults                                                        0       0
-#tmpfs          /#t#m#p         tmpfs   mode=1777                                                       0       0
+#tmpfs          /tmp            tmpfs   defaults,noatime,mode=1777,size=25%                             0       0
 
 # Add internal harddisk
 #/dev/sda1      /mnt/hd-intern  ext4    defaults,noatime                                                0       1


### PR DESCRIPTION
When the flag `--zram` is not set, ZRAM_ENABLED should be `off`